### PR TITLE
feat: Pages site (landing + install + skill), coverage under /coverage/

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,11 +33,26 @@ jobs:
         with:
           name: coverage-report
           path: artifacts/coverage-report
+      # Build the Jekyll site (landing + install + skill pages) and merge the coverage
+      # report under /coverage/ so a single Pages artifact carries both. The Jekyll source
+      # lives at the repo root (_config.yml, index.md, install.md, skill.md); coverage
+      # comes from artifacts/coverage-report/ produced by `make ci` above.
+      - name: Build Pages site (Jekyll + coverage)
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Merge coverage report into _site/coverage/
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: |
+          mkdir -p _site/coverage
+          cp -R artifacts/coverage-report/. _site/coverage/
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: actions/upload-pages-artifact@v5
         with:
-          path: artifacts/coverage-report
+          path: _site
 
   deploy-pages:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A **zero-dependency**, schema-less GraphQL query builder for .NET. Compose Graph
 [![NuGet](https://img.shields.io/nuget/v/NGql.Core)](https://www.nuget.org/packages/NGql.Core/)
 [![Downloads](https://img.shields.io/nuget/dt/NGql.Core)](https://www.nuget.org/packages/NGql.Core/)
 [![Build](https://img.shields.io/github/actions/workflow/status/dolifer/NGql/build-and-test.yml?branch=main)](https://github.com/dolifer/NGql/actions/workflows/build-and-test.yml)
-[![Line coverage](https://dolifer.github.io/NGql/badge_linecoverage.svg)](https://dolifer.github.io/NGql/)
-[![Branch coverage](https://dolifer.github.io/NGql/badge_branchcoverage.svg)](https://dolifer.github.io/NGql/)
+[![Line coverage](https://dolifer.github.io/NGql/coverage/badge_linecoverage.svg)](https://dolifer.github.io/NGql/coverage/)
+[![Branch coverage](https://dolifer.github.io/NGql/coverage/badge_branchcoverage.svg)](https://dolifer.github.io/NGql/coverage/)
 ![.NET](https://img.shields.io/badge/.NET-8.0%20%7C%209.0%20%7C%2010.0-blue)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/dolifer/NGql/blob/main/LICENSE)
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,32 @@
+title: NGql
+description: A zero-dependency, schema-less GraphQL query builder for .NET — fluent composition, runtime fragment merging, field preservation, no SDL or codegen.
+theme: jekyll-theme-cayman
+show_downloads: false
+
+# Pages-only content lives at the repo root (index.md, install.md, skill.md). Everything else
+# is library source / tests / build artifacts and must NOT be served as Pages content.
+exclude:
+  - .claude-plugin/
+  - .claude/
+  - .config/
+  - .github/
+  - artifacts/
+  - docs/
+  - node_modules/
+  - plugins/
+  - src/
+  - tests/
+  - tmp/
+  - tools/
+  - BenchmarkDotNet.Artifacts/
+  - CHANGELOG.md         # link to GitHub-rendered version, don't shadow with a Pages copy
+  - CLAUDE.md
+  - Directory.Build.props
+  - GitVersion.yml
+  - LICENSE
+  - Makefile
+  - NGql.sln
+  - NGql.sln.DotSettings.user
+  - README.md
+  - icon.png             # served from raw.githubusercontent.com instead
+  - make.cmd

--- a/index.md
+++ b/index.md
@@ -1,0 +1,86 @@
+---
+layout: default
+title: NGql
+description: A zero-dependency, schema-less GraphQL query builder for .NET.
+---
+
+A **zero-dependency, schema-less** GraphQL query builder for .NET. Compose queries and mutations from C# with a fluent API, merge fragments at runtime, and extract subsets via field-path or LINQ expression — without an SDL or codegen step.
+
+[![NuGet](https://img.shields.io/nuget/v/NGql.Core)](https://www.nuget.org/packages/NGql.Core/)
+[![Downloads](https://img.shields.io/nuget/dt/NGql.Core)](https://www.nuget.org/packages/NGql.Core/)
+[![Build](https://img.shields.io/github/actions/workflow/status/dolifer/NGql/build-and-test.yml?branch=main)](https://github.com/dolifer/NGql/actions/workflows/build-and-test.yml)
+[![Line coverage](https://dolifer.github.io/NGql/coverage/badge_linecoverage.svg)](coverage/)
+[![Branch coverage](https://dolifer.github.io/NGql/coverage/badge_branchcoverage.svg)](coverage/)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/dolifer/NGql/blob/main/LICENSE)
+
+```bash
+dotnet add package NGql.Core
+```
+
+---
+
+## What you get
+
+- **Schemaless.** No SDL, no codegen, no build-time schema validation. The consumer supplies the schema knowledge; NGql just composes.
+- **Zero runtime dependencies.** Single assembly, multi-targets `net8.0` / `net9.0` / `net10.0`.
+- **Fluent composition.** `QueryBuilder` / `FieldBuilder` keeps query construction inline with C# control flow — no template strings, no string concat.
+- **Runtime fragment merging.** `Include(otherBuilder)` joins disjoint fragments; `MergingStrategy` picks how duplicates resolve (merge, never merge, or merge-by-field-path with auto-aliasing on conflict).
+- **Field preservation.** Extract a subset of a built query by string path or by typed C# expression — useful for role-based filtering or producing a public view of a private query.
+- **Inline fragments + unions.** `OnType("Repository", b => …)` renders `... on Repository { … }` for narrowing union/interface return types.
+- **Hot-path optimized.** Span-based path parsing, lock-free reads on `FieldChildren`, in-place merge in `Include()`. Reflection is confined to the LINQ-expression preservation path; query rendering itself is reflection-free.
+
+---
+
+## Quick taste
+
+```csharp
+using NGql.Core;
+using NGql.Core.Builders;
+
+var idVar = new Variable("$id", "ID!");
+
+var query = QueryBuilder.CreateDefaultBuilder("GetUser")
+    .AddField("user",
+        new Dictionary<string, object?> { ["id"] = idVar },
+        new[] { "id", "name", "email" });
+
+Console.WriteLine(query);
+```
+
+```graphql
+query GetUser($id:ID!){
+    user(id:$id){
+        email
+        id
+        name
+    }
+}
+```
+
+Mutations use `CreateMutationBuilder("Op")` with the same fluent surface. Inline fragments use `b.OnType("Repository", r => …)` for union narrowing. Field preservation uses `PreservationBuilder.Create(src).Preserve("user.name").Build()`.
+
+---
+
+## Where to next
+
+| | |
+|---|---|
+| **[Install](install/)** | NuGet package, optional CLI tool, optional Claude Code skill — pick what you need. |
+| **[Skill](skill/)** | The companion Claude Code skill that translates "build me a query for X" → working NGql code. |
+| **[Coverage](coverage/)** | Full coverage report for the Core namespace. Currently ~99.9% line / 99% branch. |
+| **[CHANGELOG](https://github.com/dolifer/NGql/blob/main/CHANGELOG.md)** | What's in 2.1, what changed from 2.0. |
+| **[README on GitHub](https://github.com/dolifer/NGql#readme)** | Long-form docs with runnable examples for every API. |
+| **[Source](https://github.com/dolifer/NGql)** | Issues, PRs, the codebase itself. |
+
+---
+
+## Status
+
+| | |
+|---|---|
+| **Latest stable** | See the NuGet badge above. The library uses GitVersion-driven SemVer; previews ship as `<X.Y.Z>-preview.N`. |
+| **Companion tool** | [`dotnet-ngql`](install/#cli-tool-dotnet-ngql) — compiles a snippet, renders the GraphQL, optionally executes against a live endpoint. |
+| **Companion skill** | [`ngql-preview`](skill/) — a Claude Code skill in the [`dolifer` plugin marketplace](https://dolifer.github.io/claude-plugins/). |
+| **Min runtime** | .NET 8.0 |
+
+License: MIT.

--- a/install.md
+++ b/install.md
@@ -1,0 +1,98 @@
+---
+layout: default
+title: Install — NGql
+description: Install the NGql library, the dotnet-ngql CLI, and (optionally) the Claude Code skill.
+---
+
+<p><a href="{{ '/' | relative_url }}">← back to home</a></p>
+
+# Install
+
+Three independent pieces. The library is the only required one — the CLI and skill are optional companions.
+
+---
+
+## Library: `NGql.Core`
+
+```bash
+dotnet add package NGql.Core
+```
+
+Multi-targets `net8.0` / `net9.0` / `net10.0`. Zero runtime dependencies. Add the package, write `using NGql.Core; using NGql.Core.Builders;`, and you're building queries.
+
+```csharp
+using NGql.Core.Builders;
+
+var query = QueryBuilder.CreateDefaultBuilder("Hello").AddField("world.name");
+Console.WriteLine(query);
+// query Hello{
+//     world{
+//         name
+//     }
+// }
+```
+
+For the long-form docs with every API + runnable examples, see the [README on GitHub](https://github.com/dolifer/NGql#readme).
+
+---
+
+## CLI tool: `dotnet-ngql`
+
+A .NET global tool that compiles a `QueryBuilder` snippet and prints the rendered GraphQL. Optionally executes the query against a live endpoint with `--execute`. Useful for hand-verifying snippets, snapshotting expected query text in CI, or pairing with the [Claude Code skill](skill/) to run generated code without leaving your terminal.
+
+**Install (preview only — no stable release on NuGet yet):**
+
+```bash
+dotnet tool install -g dotnet-ngql --prerelease
+```
+
+The `--prerelease` flag is required while only preview versions exist. Drop it once a stable `2.x.0` ships.
+
+**Use:**
+
+```bash
+echo 'QueryBuilder.CreateDefaultBuilder("Hello").AddField("world.name")' | ngql
+# query Hello{
+#     world{
+#         name
+#     }
+# }
+
+# Execute against a live endpoint:
+echo '<snippet>' | ngql --execute \
+    --endpoint https://api.example.com/graphql \
+    -H "Authorization: Bearer $TOKEN" \
+    --var id=42
+```
+
+Mutations are refused by default — pass `--allow-mutations` once you're sure the side effect is intended. Full options: `ngql --help`.
+
+**Update:** `dotnet tool update -g dotnet-ngql --prerelease`.
+
+The tool's version tracks `NGql.Core` in lockstep — install a specific version with `--version 2.1.0-preview.X --prerelease`.
+
+---
+
+## Claude Code skill (optional)
+
+The `ngql-preview` Claude Code skill teaches Claude to author NGql code from natural language, pasted GraphQL, or curl. It pairs with the `dotnet-ngql` CLI to verify what it generated.
+
+```text
+/plugin marketplace add dolifer/claude-plugins
+/plugin install ngql-preview@dolifer
+```
+
+Then in any session: `/ngql-preview:ngql build me a query for…`.
+
+Full skill docs: [dolifer.github.io/claude-plugins/skills/ngql-preview/](https://dolifer.github.io/claude-plugins/skills/ngql-preview/).
+
+---
+
+## Verify the install
+
+```bash
+dotnet --version       # need .NET 8 SDK or newer for the library
+ngql --version         # tool version (matches the latest preview you installed)
+```
+
+Inside a Claude Code session: `/plugin` lists installed plugins; `/ngql-preview:ngql` should be among the available commands once the skill is installed.

--- a/skill.md
+++ b/skill.md
@@ -1,0 +1,63 @@
+---
+layout: default
+title: Claude Code Skill — NGql
+description: The companion Claude Code skill that translates natural language and pasted GraphQL into NGql code.
+---
+
+<p><a href="{{ '/' | relative_url }}">← back to home</a></p>
+
+# `ngql-preview` Skill
+
+A [Claude Code](https://docs.claude.com/en/docs/claude-code) skill that teaches Claude to author NGql query-builder C# from:
+
+- **Natural language** — *"Get the top 10 repos for user X with stargazer counts"* → a `QueryBuilder` snippet using the fluent API.
+- **Pasted GraphQL or curl** — preserves operation name, variable types, enum literals, nested arguments, inline fragments via `OnType`. Auth headers from a curl get captured for the next `--execute` offer so you don't retype credentials.
+- **Refactor / preserve requests** — *"Drop `ssn` and `email` from this builder"* → a `PreservationBuilder.Preserve(...)` chain that keeps everything else.
+
+It's prescriptive: it picks one safe API idiom per situation and refuses to generate code for unsupported GraphQL constructs (named fragments, directives, subscriptions). When the request needs something NGql can't model, the skill stops, names the gap, and offers concrete workarounds — instead of producing broken code with a warning.
+
+Pairs naturally with the [`dotnet-ngql` CLI](install/#cli-tool-dotnet-ngql) to verify what it generated. The skill proactively offers to render every snippet via `echo '<snippet>' | ngql` (asking once per session for render-only; always asking per call for `--execute` since that touches a server).
+
+---
+
+## Install
+
+```text
+/plugin marketplace add dolifer/claude-plugins
+/plugin install ngql-preview@dolifer
+```
+
+Then invoke as `/ngql-preview:ngql` in any Claude Code session. To pull updates later:
+
+```text
+/plugin marketplace update
+/plugin update ngql-preview@dolifer
+/reload-plugins
+```
+
+---
+
+## Channels
+
+| Channel | Plugin name | Status |
+|---|---|---|
+| **Preview** | `ngql-preview` | Live — tracks the latest `NGql.Core` preview. Allowed to break and iterate. |
+| **Stable** | `ngql` | Coming soon — first stable release gates on the skill content stabilizing in preview. |
+
+Both can coexist in the same Claude Code session: `/ngql:ngql` invokes stable, `/ngql-preview:ngql` invokes preview. Useful for comparing behavior or A/B-ing a skill change before promoting.
+
+---
+
+## Full skill documentation
+
+The skill marketplace site has the canonical docs, frontmatter, version, and changelog:
+
+**→ [dolifer.github.io/claude-plugins/skills/ngql-preview/](https://dolifer.github.io/claude-plugins/skills/ngql-preview/)**
+
+Source-of-truth for editing the skill content lives in this repo at [`.claude/skills/ngql-local/SKILL.md`](https://github.com/dolifer/NGql/blob/main/.claude/skills/ngql-local/SKILL.md). The catalog repo receives the published content via CI on every push to `main` that touches the skill folder.
+
+---
+
+## Reporting skill issues
+
+Open in [dolifer/NGql/issues](https://github.com/dolifer/NGql/issues) with the `skill` label. The skill content is generated from this repo, so a fix lands in the marketplace catalog automatically on the next preview publish.


### PR DESCRIPTION
## Summary

- Replace the bare-coverage-report-as-Pages with a Jekyll site at the repo root: `index.md` (landing), `install.md` (NuGet + tool + skill), `skill.md` (skill intro + link to marketplace docs).
- Move the existing coverage report under `/coverage/` so the same Pages artifact carries both. Build-and-test workflow now does `jekyll-build-pages` → merge `artifacts/coverage-report/` into `_site/coverage/` → upload `_site` as the Pages artifact.
- Update README badge URLs to point at the new `/coverage/` subpath, in the same commit so badges never 404.

## Validation done

- All Jekyll sources are at the repo root with explicit `exclude:` in `_config.yml` for everything that's library source / tests / build artifacts. Cayman theme matches the `dolifer/claude-plugins` Pages site for consistency.
- Workflow change is minimal: one step replaced (`Upload Pages artifact`) with three (`Build Pages site (Jekyll + coverage)` + `Merge coverage report into _site/coverage/` + `Upload Pages artifact`). All gated on the existing `if: github.ref == 'refs/heads/main' && github.event_name == 'push'` condition.

## Test plan

- [ ] Merge to `main`. Watch `Build & Test` workflow complete on the merge commit.
- [ ] Verify live URLs:
  - `https://dolifer.github.io/NGql/` (landing)
  - `https://dolifer.github.io/NGql/install/` (install page)
  - `https://dolifer.github.io/NGql/skill/` (skill page)
  - `https://dolifer.github.io/NGql/coverage/` (coverage report)
  - `https://dolifer.github.io/NGql/coverage/badge_linecoverage.svg` (coverage badge — the new path README references)
- [ ] Open the README on GitHub and confirm coverage badges render and click through to the new `/coverage/` page.